### PR TITLE
Add button to header for website redirect

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import { Logo } from "./Logo";
+import { ExternalLink } from "lucide-react";
+import { Button } from "./ui/button";
 
 interface HeaderProps {
   isMobile: boolean;
@@ -9,6 +11,13 @@ export const Header = ({ isMobile }: HeaderProps) => {
     <header className="border-b bg-white">
       <div className="container mx-auto px-4 py-4 flex justify-between items-center">
         <Logo />
+        <Button
+          onClick={() => window.location.href = 'https://chatsites.ai'}
+          className="bg-[#f65228] hover:bg-[#f65228]/90 text-white"
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          Back to Website
+        </Button>
       </div>
     </header>
   );


### PR DESCRIPTION
Implemented an orange button in the top right corner of the header that redirects users to the ChatSites.AI webpage. The button is labeled "Back to Website". [skip gpt_engineer]